### PR TITLE
SQLite3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ The simplest way to group by:
 - hour of the day
 - and more (complete list at bottom)
 
-:tada: Time zones supported!! **the best part**
+:tada: Time zones supported!! **the best part** (...except for SQLite :unamused:)
 
 :cake: Get the entire series - **the other best part**
 
 Works with Rails 3.0+
 
-Supports PostgreSQL and MySQL
+Supports PostgreSQL, MySQL, and SQLite
 
 [![Build Status](https://travis-ci.org/ankane/groupdate.png)](https://travis-ci.org/ankane/groupdate)
 
@@ -195,6 +195,11 @@ group_by_?
 - day_of_week
 
 ## Note
+
+[SQLite has no concept of timezones](http://marc.info/?l=sqlite-users&m=109798367320017) outside of primitive "localtime"
+to UTC conversions.  Time zones specified in queries are silently ignored, and columns are implicitly assumed to be, and
+reported back as, UTC.  Don't try to get too clever.
+
 
 activerecord <= 4.0.0.beta1 and the pg gem returns String objects instead of Time objects.
 [This is fixed on activerecord master](https://github.com/rails/rails/commit/2cc09441c2de57b024b11ba666ba1e72c2b20cfe)

--- a/groupdate.gemspec
+++ b/groupdate.gemspec
@@ -30,5 +30,6 @@ Gem::Specification.new do |spec|
   else
     spec.add_development_dependency "pg"
     spec.add_development_dependency "mysql2"
+    spec.add_development_dependency "sqlite3"
   end
 end

--- a/lib/groupdate/scopes.rb
+++ b/lib/groupdate/scopes.rb
@@ -83,6 +83,33 @@ module Groupdate
                 else
                   ["DATE_TRUNC('#{field}', #{column}::timestamptz AT TIME ZONE ?) AT TIME ZONE ?", time_zone, time_zone]
                 end
+              when 'SQLite'
+                if field == "week"
+                  ["strftime('%%Y-%%m-%%d 00:00:00 UTC', #{column}, '-6 days', 'weekday 0')"]
+                else
+                  format =
+                    case field
+                      when "hour_of_day"
+                        "%H"
+                      when "day_of_week"
+                        "%w"
+                      when "second"
+                        "%Y-%m-%d %H:%M:%S UTC"
+                      when "minute"
+                        "%Y-%m-%d %H:%M:00 UTC"
+                      when "hour"
+                        "%Y-%m-%d %H:00:00 UTC"
+                      when "day"
+                        "%Y-%m-%d 00:00:00 UTC"
+                      when "month"
+                        "%Y-%m-01 00:00:00 UTC"
+                      when "year"
+                        "%Y-01-01 00:00:00 UTC"
+                      else
+                        raise "Unrecognized grouping: #{field}."
+                      end
+                    ["strftime('#{format.gsub(/%/, '%%')}', #{column})"]
+                end
               else
                 raise "Connection adapter not supported: #{connection.adapter_name}"
               end


### PR DESCRIPTION
I don't consider this a proper pull request that should be merged, because it's nearly impossible to support groupdate's time zone functionality in SQLite.

However, anyone prototyping with SQLite, searching the issues for adapter support, may be interested in this branch.  Time zones are silently ignored, and assumed to be UTC.  The existing Postgres and MySQL tests pass, SQLite tests requiring timezone support are skipped.