### PR TITLE
Fix series in Rails 3.0

### DIFF
--- a/lib/groupdate/series.rb
+++ b/lib/groupdate/series.rb
@@ -68,7 +68,7 @@ module Groupdate
             series << series.last + step
           end
 
-          series.map{|s| s.to_time }
+          series.map{|s| s.to_time.utc }  # Rails 3.0 stable
         end
 
       Hash[series.map do |k|


### PR DESCRIPTION
The `count` hash's keys are `Time`s in UTC.  For the `series` to
correspond to these keys, `series` must also be UTC time instances.

However In Rails 3.0 `TimeWithZone#to_time` returns `self` which presents
the time in the local timezone.

https://github.com/rails/rails/blob/77403a9b04073713e2b758c22174a81bb3cd62b9/activesupport/lib/active_support/time_with_zone.rb#L282

In Rails 3.2 the same method returns `utc.to_time`, i.e. an instance of
Time in the system timezone.

https://github.com/rails/rails/blob/17a113289dccf276bf316b99fa13dbfa9ff759d2/activesupport/lib/active_support/time_with_zone.rb#L326
