### PR TITLE
Add group_calc to enable custom calculations

### DIFF
--- a/lib/groupdate/magic.rb
+++ b/lib/groupdate/magic.rb
@@ -113,10 +113,18 @@ module Groupdate
         end
 
       count =
-        begin
-          Hash[ relation.send(method, *args, &block).map{|k, v| [multiple_groups ? k[0...@group_index] + [cast_method.call(k[@group_index])] + k[(@group_index + 1)..-1] : cast_method.call(k), v] } ]
-        rescue NoMethodError
-          raise "Be sure to install time zone support - https://github.com/ankane/groupdate#for-mysql"
+        if method == :group_calc
+          begin
+            Hash[relation.select("#{relation.group_values[@group_index]} AS #{@field.to_s}", "#{args[0]} AS calculation").group("#{relation.group_values[@group_index]}").map { |record| [record.send(@field), record.calculation] }]
+          rescue
+            raise "Could not perform custom calculation. Please check your syntax."
+          end
+        else
+          begin
+            Hash[ relation.send(method, *args, &block).map{|k, v| [multiple_groups ? k[0...@group_index] + [cast_method.call(k[@group_index])] + k[(@group_index + 1)..-1] : cast_method.call(k), v] } ]
+          rescue NoMethodError
+            raise "Be sure to install time zone support - https://github.com/ankane/groupdate#for-mysql"
+          end
         end
 
       series(count, 0, multiple_groups, reverse)

--- a/lib/groupdate/series.rb
+++ b/lib/groupdate/series.rb
@@ -10,7 +10,7 @@ module Groupdate
     # clone to prevent modifying original variables
     def method_missing(method, *args, &block)
       # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/relation/calculations.rb
-      if ActiveRecord::Calculations.method_defined?(method)
+      if ActiveRecord::Calculations.method_defined?(method) || method == :group_calc
         magic.perform(relation, method, *args, &block)
       elsif @relation.respond_to?(method)
         Groupdate::Series.new(magic, relation.send(method, *args, &block))


### PR DESCRIPTION
This is an update to #47 that uses the latest groupdate refactor in an effort to simplify the interface for the user. The new DSL would be to use `group_calc` from a `Groupdate::Series`:

```ruby
User.group_by_month(:created_at).group_calc("(SUM(logins) / AVG(age))")
```