### PR TITLE
Add ability to carry forward values from previous intervals

### DIFF
--- a/lib/groupdate/magic.rb
+++ b/lib/groupdate/magic.rb
@@ -226,8 +226,12 @@ module Groupdate
           lambda{|k| k }
         end
 
+      value = nil
+
       Hash[series.map do |k|
-        [multiple_groups ? k[0...@group_index] + [key_format.call(k[@group_index])] + k[(@group_index + 1)..-1] : key_format.call(k), count[k] || default_value]
+        value = count[k] || (@options[:carry_forward] ? value : false) || default_value
+
+        [multiple_groups ? k[0...@group_index] + [key_format.call(k[@group_index])] + k[(@group_index + 1)..-1] : key_format.call(k), value]
       end]
     end
 


### PR DESCRIPTION
Adds the `carry_forward` option to `Groupdate::Magic` to allow values to be carried forward from previous intervals when missing.

So this:

``` ruby
User.group_by_month(:created_at).sum(:posts)
=> {Sun, 01 Dec 2013 00:00:00 EST -05:00=>1,
 Wed, 01 Jan 2014 00:00:00 EST -05:00=>3,
 Sat, 01 Feb 2014 00:00:00 EST -05:00=>0,
 Sat, 01 Mar 2014 00:00:00 EST -05:00=>0,
 Tue, 01 Apr 2014 00:00:00 EDT -04:00=>5,
 Thu, 01 May 2014 00:00:00 EDT -04:00=>0,
 Sun, 01 Jun 2014 00:00:00 EDT -04:00=>25}
```

Changes to this:

``` ruby
User.group_by_month(:created_at, carry_forward: true).sum(:posts)
=> {Sun, 01 Dec 2013 00:00:00 EST -05:00=>1,
 Wed, 01 Jan 2014 00:00:00 EST -05:00=>3,
 Sat, 01 Feb 2014 00:00:00 EST -05:00=>3,
 Sat, 01 Mar 2014 00:00:00 EST -05:00=>3,
 Tue, 01 Apr 2014 00:00:00 EDT -04:00=>5,
 Thu, 01 May 2014 00:00:00 EDT -04:00=>5,
 Sun, 01 Jun 2014 00:00:00 EDT -04:00=>25}
```
