### PR TITLE
Fix NoMethodError (private method reverse_order_value in AR 4.2

### DIFF
--- a/lib/groupdate/magic.rb
+++ b/lib/groupdate/magic.rb
@@ -108,7 +108,7 @@ module Groupdate
 
     def perform(relation, method, *args, &block)
       # undo reverse since we do not want this to appear in the query
-      reverse = relation.reverse_order_value
+      reverse = relation.send(:reverse_order_value)
       if reverse
         relation = relation.except(:reverse_order)
       end


### PR DESCRIPTION
Apparently reverse_order_value is now private in Active Record 4.2.
This resolved my issues, but I'm not sure it is the best solution (calling private methods).