### PR TITLE
Do not attempt to require active_record if defined

### DIFF
--- a/lib/groupdate.rb
+++ b/lib/groupdate.rb
@@ -1,5 +1,7 @@
-require "active_support/core_ext/module/attribute_accessors"
-require "active_support/time"
+unless defined?(ActiveSupport)
+  require "active_support/time"
+  require "active_support/core_ext/module/attribute_accessors"
+end
 require "groupdate/version"
 require "groupdate/magic"
 

--- a/lib/groupdate.rb
+++ b/lib/groupdate.rb
@@ -6,8 +6,8 @@ require "groupdate/version"
 require "groupdate/magic"
 
 module Groupdate
-  FIELDS = [:second, :minute, :hour, :day, :week, :month, :year, :day_of_week, :hour_of_day, :day_of_month, :month_of_year]
-  METHODS = FIELDS.map { |v| :"group_by_#{v}" }
+  FIELDS = [:second, :minute, :hour, :day, :week, :month, :year, :day_of_week, :hour_of_day, :day_of_month, :month_of_year].freeze
+  METHODS = FIELDS.map { |v| :"group_by_#{v}" }.freeze
 
   mattr_accessor :week_start, :day_start, :time_zone
   self.week_start = :sun
@@ -16,7 +16,7 @@ end
 
 require "groupdate/enumerable"
 begin
-  require "active_record"
+  require "active_record" unless defined?(ActiveRecord)
 rescue LoadError
   # do nothing
 end

--- a/lib/groupdate/active_record.rb
+++ b/lib/groupdate/active_record.rb
@@ -1,4 +1,4 @@
-require "active_record"
+require "active_record" unless defined?(ActiveRecord)
 require "groupdate/order_hack"
 require "groupdate/scopes"
 require "groupdate/series"


### PR DESCRIPTION
Hi!

Thanks for a great gem :+1: 

I was playing with [derailed_benchmarks](https://github.com/schneems/derailed_benchmarks) to understand one of my app's memory footprint and *groupdate* stumbled high on the list. If I'm not reading the results wrong, it has to do with the attempt to `require active_record` even if it's already been required. I actually don't fully understand what's going on, if I understand `require` correctly, it should not try to do anything if it has been required ... but this are the results of `CUT_OFF=0.5 derailed bundle:mem` before

    groupdate: 8.0156 MiB
      groupdate/active_record: 7.668 MiB

and after:

    groupdate: 1.1836 MiB
      groupdate/active_record: 1.1797 MiB

Thanks!