### PR TITLE
Added default_value option

### DIFF
--- a/lib/groupdate/magic.rb
+++ b/lib/groupdate/magic.rb
@@ -140,7 +140,7 @@ module Groupdate
           raise "Be sure to install time zone support - https://github.com/ankane/groupdate#for-mysql"
         end
 
-      series(count, 0, multiple_groups, reverse)
+      series(count, (options.has_key?(:default_value) ? options[:default_value] : 0), multiple_groups, reverse)
     end
 
     protected


### PR DESCRIPTION
Missing / default values are 0 but I think you should be able to override this

For example: `group_by_week(:date, last: 8, default_value: nil)`

Feedback is welcome!