### PR TITLE
Allow symbols for format: option

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ User.group_by_hour_of_day(:created_at, format: "%-l %P").count
 # }
 ```
 
-Takes a `String`, which is passed to [strftime](http://strfti.me/), or a `Proc`.  You can pass a locale with the `locale` option.
+Takes a `String`, which is passed to [strftime](http://strfti.me/), or a `Symbol`, which is looked up by `I18n.localize` in `i18n` scope 'time.formats', or a `Proc`.  You can pass a locale with the `locale` option.
 
 ### Dynamic Grouping
 

--- a/lib/groupdate/magic.rb
+++ b/lib/groupdate/magic.rb
@@ -245,7 +245,7 @@ module Groupdate
               when :month_of_year
                 key = Date.new(2014, key, 1).to_time
               end
-              I18n.localize(key, format: options[:format].to_s, locale: locale)
+              I18n.localize(key, format: options[:format], locale: locale)
             end
           end
         else

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,6 +26,9 @@ end
 I18n.enforce_available_locales = true
 I18n.backend.store_translations :de, date: {
   abbr_month_names: %w(Jan Feb Mar Apr Mai Jun Jul Aug Sep Okt Nov Dez).unshift(nil)
+},
+time: {
+  formats: {special: '%b %e, %Y'}
 }
 
 # migrations
@@ -756,6 +759,11 @@ module TestGroupdate
   def test_format_locale
     create_user "2014-10-01 00:00:00 UTC"
     assert_equal ({"Okt" => 1}), User.group_by_day(:created_at, format: "%b", locale: :de).count
+  end
+
+  def test_format_locale_by_symbol
+    create_user "2014-10-01 00:00:00 UTC"
+    assert_equal ({"Okt  1, 2014" => 1}), User.group_by_day(:created_at, format: :special, locale: :de).count
   end
 
   def test_format_locale_global


### PR DESCRIPTION
I have my doubts about default 'time.formats' scope instead of 'date.formats' which probably would be more suitable for group_by_day and group_by_month, still I think in multi-language application format should be dependent on locale.
Anyways, I'm not sure what was the purpose of `to_s` of format option in original code. This pull request shouldn't hurt anyone.