### PR TITLE
Remove duplicate test.

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -78,10 +78,6 @@ module TestDatabase
     assert_equal 23, User.group_by_hour_of_day(:created_at).order("hour_of_day desc").count.keys.first
   end
 
-  def test_order_hour_of_day_case
-    assert_equal 23, User.group_by_hour_of_day(:created_at).order("hour_of_day DESC").count.keys.first
-  end
-
   def test_order_hour_of_day_reverse
     skip if ActiveRecord::VERSION::MAJOR == 5
     assert_equal 23, User.group_by_hour_of_day(:created_at).reverse_order.count.keys.first


### PR DESCRIPTION
- No need to test twice for case sensitive for order 'desc' & 'DESC' . SQL server
takes care of it.