### PR TITLE
Allow custom model calculation methods

### DIFF
--- a/lib/groupdate/series.rb
+++ b/lib/groupdate/series.rb
@@ -10,7 +10,7 @@ module Groupdate
     # clone to prevent modifying original variables
     def method_missing(method, *args, &block)
       # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/relation/calculations.rb
-      if ActiveRecord::Calculations.method_defined?(method) || custom_calculation_methods.include?(method)
+      if ActiveRecord::Calculations.method_defined?(method) || custom_calculation_method?(method)
         magic.perform(relation, method, *args, &block)
       elsif relation.respond_to?(method, true)
         Groupdate::Series.new(magic, relation.send(method, *args, &block))
@@ -29,14 +29,18 @@ module Groupdate
 
     private
 
-    def model
-      return if !relation.respond_to?(:klass)
-
-      relation.klass
+    def custom_calculation_method?(method)
+      custom_calculation_methods.include?(method)
     end
 
     def custom_calculation_methods
-      model.try(:groupdate_calculation_methods) || []
+      return [] if !model.respond_to?(:groupdate_calculation_methods)
+      model.groupdate_calculation_methods
+    end
+
+    def model
+      return if !relation.respond_to?(:klass)
+      relation.klass
     end
   end
 end

--- a/lib/groupdate/series.rb
+++ b/lib/groupdate/series.rb
@@ -30,7 +30,9 @@ module Groupdate
     private
 
     def model
-      relation.try(:model)
+      return if !relation.respond_to?(:klass)
+
+      relation.klass
     end
 
     def custom_calculation_methods

--- a/lib/groupdate/series.rb
+++ b/lib/groupdate/series.rb
@@ -5,12 +5,12 @@ module Groupdate
     def initialize(magic, relation)
       @magic = magic
       @relation = relation
+      @calculations = Groupdate::Calculations.new(relation)
     end
 
     # clone to prevent modifying original variables
     def method_missing(method, *args, &block)
-      # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/relation/calculations.rb
-      if ActiveRecord::Calculations.method_defined?(method) || custom_calculation_method?(method)
+      if @calculations.include?(method)
         magic.perform(relation, method, *args, &block)
       elsif relation.respond_to?(method, true)
         Groupdate::Series.new(magic, relation.send(method, *args, &block))
@@ -20,23 +20,32 @@ module Groupdate
     end
 
     def respond_to?(method, include_all = false)
-      ActiveRecord::Calculations.method_defined?(method) || relation.respond_to?(method) || super
+      @calculations.include?(method) || relation.respond_to?(method) || super
     end
 
     def reverse_order_value
       nil
     end
+  end
 
-    private
+  class Calculations
+    attr_reader :relation
 
-    def custom_calculation_method?(method)
-      custom_calculation_methods.include?(method)
+    def initialize(relation)
+      @relation = relation
     end
 
-    def custom_calculation_methods
+    def include?(method)
+      # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/relation/calculations.rb
+      ActiveRecord::Calculations.method_defined?(method) || custom_calculations.include?(method)
+    end
+
+    def custom_calculations
       return [] if !model.respond_to?(:groupdate_calculation_methods)
       model.groupdate_calculation_methods
     end
+
+    private
 
     def model
       return if !relation.respond_to?(:klass)

--- a/lib/groupdate/series.rb
+++ b/lib/groupdate/series.rb
@@ -10,9 +10,9 @@ module Groupdate
     # clone to prevent modifying original variables
     def method_missing(method, *args, &block)
       # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/relation/calculations.rb
-      if ActiveRecord::Calculations.method_defined?(method)
+      if ActiveRecord::Calculations.method_defined?(method) || custom_calculation_methods.include?(method)
         magic.perform(relation, method, *args, &block)
-      elsif @relation.respond_to?(method, true)
+      elsif relation.respond_to?(method, true)
         Groupdate::Series.new(magic, relation.send(method, *args, &block))
       else
         super
@@ -25,6 +25,16 @@ module Groupdate
 
     def reverse_order_value
       nil
+    end
+
+    private
+
+    def model
+      relation.try(:model)
+    end
+
+    def custom_calculation_methods
+      model.try(:groupdate_calculation_methods) || []
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -354,6 +354,22 @@ module TestDatabase
     assert_raises(ArgumentError) { User.group_by_day.first }
   end
 
+  # custom aggregate model methods
+
+  def test_custom_model_aggregate_method
+    create_user "2014-05-01 00:00:00 UTC", 11
+    create_user "2014-05-01 00:00:00 UTC",  5
+    create_user "2014-05-03 00:00:00 UTC", 20
+
+    expected = {
+      Date.parse("2014-05-01") => (16.0 / 2.0).to_d,
+      Date.parse("2014-05-02") => 0.0.to_d,
+      Date.parse("2014-05-03") => 20.0.to_d
+    }
+
+    assert_equal expected, User.group_by_day(:created_at).avg_score
+  end
+
   private
 
   def call_method(method, field, options)
@@ -1037,22 +1053,6 @@ module TestGroupdate
 
   def test_day_start_decimal_start_of_day
     assert_result_date :day, "2013-05-03", "2013-05-03 02:30:00", false, day_start: 2.5
-  end
-
-  # custom aggregate model methods
-
-  def test_custom_model_aggregate_method
-    create_user "2014-05-01 00:00:00 UTC", 11
-    create_user "2014-05-01 00:00:00 UTC",  5
-    create_user "2014-05-03 00:00:00 UTC", 20
-
-    expected = {
-      Date.parse("2014-05-01") => (16.0 / 2.0).to_d,
-      Date.parse("2014-05-02") => 0.0.to_d,
-      Date.parse("2014-05-03") => 20.0.to_d
-    }
-
-    assert_equal expected, User.group_by_day(:created_at).avg_score
   end
 
   private

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,10 +20,10 @@ class User < ActiveRecord::Base
   has_many :posts
 
   def self.groupdate_calculation_methods
-    [:avg_score]
+    [:average_score]
   end
 
-  def self.avg_score
+  def self.average_score
     average(:score)
   end
 end
@@ -357,17 +357,17 @@ module TestDatabase
   # custom aggregate model methods
 
   def test_custom_model_aggregate_method
-    create_user "2014-05-01 00:00:00 UTC", 11
-    create_user "2014-05-01 00:00:00 UTC",  5
-    create_user "2014-05-03 00:00:00 UTC", 20
+    create_user "2014-05-01", 11
+    create_user "2014-05-01",  5
+    create_user "2014-05-03", 20
 
     expected = {
-      Date.parse("2014-05-01") => (16.0 / 2.0).to_d,
-      Date.parse("2014-05-02") => 0.0.to_d,
-      Date.parse("2014-05-03") => 20.0.to_d
+      Date.parse("2014-05-01") =>  8.0,
+      Date.parse("2014-05-02") =>  0.0,
+      Date.parse("2014-05-03") => 20.0
     }
 
-    assert_equal expected, User.group_by_day(:created_at).avg_score
+    assert_equal expected, User.group_by_day(:created_at).average_score
   end
 
   private

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,11 +20,11 @@ class User < ActiveRecord::Base
   has_many :posts
 
   def self.groupdate_calculation_methods
-    [:distinct_scores_count]
+    [:custom_count]
   end
 
-  def self.distinct_scores_count
-    distinct.count(:score)
+  def self.custom_count
+    count
   end
 end
 
@@ -358,7 +358,6 @@ module TestDatabase
 
   def test_custom_model_aggregate_method
     create_user "2014-05-01", 1
-    create_user "2014-05-01", 1
     create_user "2014-05-01", 2
     create_user "2014-05-03", 3
 
@@ -368,7 +367,7 @@ module TestDatabase
       Date.parse("2014-05-03") => 1
     }
 
-    assert_equal expected, User.group_by_day(:created_at).distinct_scores_count
+    assert_equal expected, User.group_by_day(:created_at).custom_count
   end
 
   private

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,11 +20,11 @@ class User < ActiveRecord::Base
   has_many :posts
 
   def self.groupdate_calculation_methods
-    [:average_score]
+    [:distinct_scores_count]
   end
 
-  def self.average_score
-    average(:score)
+  def self.distinct_scores_count
+    distinct.count(:score)
   end
 end
 
@@ -357,17 +357,18 @@ module TestDatabase
   # custom aggregate model methods
 
   def test_custom_model_aggregate_method
-    create_user "2014-05-01", 11
-    create_user "2014-05-01",  5
-    create_user "2014-05-03", 20
+    create_user "2014-05-01", 1
+    create_user "2014-05-01", 1
+    create_user "2014-05-01", 2
+    create_user "2014-05-03", 3
 
     expected = {
-      Date.parse("2014-05-01") =>  8.0,
-      Date.parse("2014-05-02") =>  0.0,
-      Date.parse("2014-05-03") => 20.0
+      Date.parse("2014-05-01") => 2,
+      Date.parse("2014-05-02") => 0,
+      Date.parse("2014-05-03") => 1
     }
 
-    assert_equal expected, User.group_by_day(:created_at).average_score
+    assert_equal expected, User.group_by_day(:created_at).distinct_scores_count
   end
 
   private

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,10 +20,14 @@ class User < ActiveRecord::Base
   has_many :posts
 
   def self.groupdate_calculation_methods
-    [:custom_count]
+    [:custom_count, :undefined_calculation]
   end
 
   def self.custom_count
+    count
+  end
+
+  def self.unlisted_calculation
     count
   end
 end
@@ -354,9 +358,9 @@ module TestDatabase
     assert_raises(ArgumentError) { User.group_by_day.first }
   end
 
-  # custom aggregate model methods
+  # custom model calculation methods
 
-  def test_custom_model_aggregate_method
+  def test_custom_model_calculation_method
     create_user "2014-05-01", 1
     create_user "2014-05-01", 2
     create_user "2014-05-03", 3
@@ -368,6 +372,16 @@ module TestDatabase
     }
 
     assert_equal expected, User.group_by_day(:created_at).custom_count
+  end
+
+  def test_using_unlisted_calculation_method_returns_new_series_instance
+    assert_instance_of Groupdate::Series, User.group_by_day(:created_at).unlisted_calculation
+  end
+
+  def test_using_listed_but_undefined_custom_calculation_method_raises_error
+    assert_raises do
+      User.group_by_day(:created_at).undefined_calculation
+    end
   end
 
   private

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,14 @@ ActiveRecord::Base.time_zone_aware_attributes = true
 
 class User < ActiveRecord::Base
   has_many :posts
+
+  def self.groupdate_calculation_methods
+    [:avg_score]
+  end
+
+  def self.avg_score
+    average(:score)
+  end
 end
 
 class Post < ActiveRecord::Base
@@ -1029,6 +1037,22 @@ module TestGroupdate
 
   def test_day_start_decimal_start_of_day
     assert_result_date :day, "2013-05-03", "2013-05-03 02:30:00", false, day_start: 2.5
+  end
+
+  # custom aggregate model methods
+
+  def test_custom_model_aggregate_method
+    create_user "2014-05-01 00:00:00 UTC", 11
+    create_user "2014-05-01 00:00:00 UTC",  5
+    create_user "2014-05-03 00:00:00 UTC", 20
+
+    expected = {
+      Date.parse("2014-05-01") => (16.0 / 2.0).to_d,
+      Date.parse("2014-05-02") => 0.0.to_d,
+      Date.parse("2014-05-03") => 20.0.to_d
+    }
+
+    assert_equal expected, User.group_by_day(:created_at).avg_score
   end
 
   private

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -379,7 +379,7 @@ module TestDatabase
   end
 
   def test_using_listed_but_undefined_custom_calculation_method_raises_error
-    assert_raises do
+    assert_raises(RuntimeError) do
       User.group_by_day(:created_at).undefined_calculation
     end
   end


### PR DESCRIPTION
Our initial discussion was part of issue #73.

Allows the use of custom aggregation methods defined on ActiveRecord models.

```ruby
class User < ActiveRecord::Base
  def self.groupdate_calculation_methods
    [:avg_score]
  end

  def self.avg_score
    average(:score)
  end
end

User.group_by_week(:created_at).avg_score
```
