### PR TITLE
Add docs around custom calculation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,44 @@ Count
 Hash[ users.group_by_day { |u| u.created_at }.map { |k, v| [k, v.size] } ]
 ```
 
+## Custom Calculation methods
+
+Groupdate knows all of the calculations defined by `ActiveRecord` like `count`,
+`sum`, or `average`. However you may have your own class level calculation
+methods that you need to tell Groupdate about. All you have to do is define the
+class method `groupdate_calculation_methods` returning an array of the method
+names as symbols.
+
+```ruby
+# User class...
+def self.groupdate_calculation_methods
+  [
+    :total_sign_ins,
+  ]
+end
+
+
+def self.total_sign_ins
+  all.sum(:sign_ins)
+end
+```
+
+Then you can use your custom calculation method
+
+```ruby
+User.group_by_week(:created_at).total_sign_ins
+# {
+#   Sun, 06 Mar 2016 => 70,
+#   Sun, 13 Mar 2016 => 54,
+#   Sun, 20 Mar 2016 => 80
+# }
+```
+
+Note that even if your method uses one of the calculations from `ActiveRecord`,
+you'll still need to add it to the `groupdate_calculation_methods` array to have
+it return the Hash of dates to values. Otherwise it will return a
+`Groupdate::Series` object.
+
 ## Installation
 
 Add this line to your application’s Gemfile:


### PR DESCRIPTION
It is quite possible that this isn't a common situation, but I was recently trying to use Groupdate with my own calculation methods. Basically, I was trying to save myself from writing `.sum("some SQL")` all over my code with a class function on the Model (e.g. `Model.sum_all_the_things`).

However, I was getting back `Groupdate::Series` instead of Hashes. When I did some digging I discovered that it had to do with what Groupdate considers "calculation" methods. Thankfully, I also discovered that Groupdate supports specifying custom calculation methods! However my discovery required digging through the gem's code, so I thought I'd add some documentation on the custom calculation method support to make it easier for others to discover. :+1:  