### PR TITLE
updated 4.0.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## 4.0.2
 
 - Make `current` option work without `last`
-- Fixed default value for `maximum`, `minimum`, and `average`
+- Fixed default value for `maximum`, `minimum`, and `average` (periods with no results will now return `nil` instead of `0`, to return `0` pass `default_value: 0` in your grouping function)
 
 ## 4.0.1
 


### PR DESCRIPTION
Hey guys, thanks for the gem. Just wanted you to be aware of a change in `4.0.2` - for this query:

```
Conversation.group_by_hour(:processing_finished_at).where('processing_finished_at > ?', 1.week.ago).average(:processing_duration)
```
I used to get results like:
```
{Thu, 01 Nov 2018 17:00:00 UTC +00:00=>0.85e1,
 Thu, 01 Nov 2018 18:00:00 UTC +00:00=>0,
 Thu, 01 Nov 2018 19:00:00 UTC +00:00=>0,
 Thu, 01 Nov 2018 20:00:00 UTC +00:00=>0,
...
 Tue, 06 Nov 2018 16:00:00 UTC +00:00=>0.86923076923076923e1,
 Tue, 06 Nov 2018 17:00:00 UTC +00:00=>0.79285714285714286e1}
```
and after `4.0.2` I get:
```
{Thu, 01 Nov 2018 17:00:00 UTC +00:00=>0.85e1,
 Thu, 01 Nov 2018 18:00:00 UTC +00:00=>nil,
 Thu, 01 Nov 2018 19:00:00 UTC +00:00=>nil,
 Thu, 01 Nov 2018 20:00:00 UTC +00:00=>nil,
...
 Tue, 06 Nov 2018 16:00:00 UTC +00:00=>0.86923076923076923e1,
 Tue, 06 Nov 2018 17:00:00 UTC +00:00=>0.79285714285714286e1}
```
I reviewed the commit history and documentation and while I see the introduction of `default_value` (`.group_by_hour(:processing_finished_at, default_value: 0)` fixes the issue for me) the change wasn't clear to me based on the changelog or documentation - a bit more info on this change in the changelog would have helped me and may help others as well.
