### PR TITLE
Fixed mysql adapter issue with Daylight Saving Time transitions

### DIFF
--- a/lib/groupdate/relation_builder.rb
+++ b/lib/groupdate/relation_builder.rb
@@ -16,8 +16,29 @@ module Groupdate
       end
     end
 
+
+    def render_aliasable_with_ugly_hack value
+      value.define_singleton_method(:relation) do
+        nothing = ''
+        nothing.define_singleton_method(:name) do
+          "groupdate_special_#{Time.now.to_i}"
+        end
+        return nothing
+      end
+
+      value.define_singleton_method(:name) do
+        "alias"
+      end
+
+      return value
+    end
+
+
+
     def generate
-      @relation.group(group_clause).where(*where_clause)
+      group_clause_evaluated = group_clause()
+      render_aliasable_with_ugly_hack(group_clause_evaluated)
+      @relation.group(group_clause_evaluated).where(*where_clause)
     end
 
     private

--- a/lib/groupdate/relation_builder.rb
+++ b/lib/groupdate/relation_builder.rb
@@ -42,7 +42,7 @@ module Groupdate
           when :month_of_year
             ["MONTH(CONVERT_TZ(DATE_SUB(#{column}, INTERVAL #{day_start} second), '+00:00', ?))", time_zone]
           when :week
-            ["CONVERT_TZ(DATE_FORMAT(CONVERT_TZ(DATE_SUB(#{column}, INTERVAL ((#{7 - week_start} + WEEKDAY(CONVERT_TZ(#{column}, '+00:00', ?) - INTERVAL #{day_start} second)) % 7) DAY) - INTERVAL #{day_start} second, '+00:00', ?), '%Y-%m-%d 00:00:00') + INTERVAL #{day_start} second, ?, '+00:00')", time_zone, time_zone, time_zone]
+            ["CONVERT_TZ(DATE_FORMAT(DATE_SUB(CONVERT_TZ(#{column}, '+00:00', ?),INTERVAL ((#{7 - week_start} + WEEKDAY(CONVERT_TZ(#{column}, '+00:00', ?) - INTERVAL #{day_start} second)) % 7) DAY) - INTERVAL #{day_start} second,'%Y-%m-%d 00:00:00') + INTERVAL #{day_start} second, ?, '+00:00')", time_zone, time_zone, time_zone]
           when :quarter
             ["DATE_ADD(CONVERT_TZ(DATE_FORMAT(DATE(CONCAT(EXTRACT(YEAR FROM CONVERT_TZ(DATE_SUB(#{column}, INTERVAL #{day_start} second), '+00:00', ?)), '-', LPAD(1 + 3 * (QUARTER(CONVERT_TZ(DATE_SUB(#{column}, INTERVAL #{day_start} second), '+00:00', ?)) - 1), 2, '00'), '-01')), '%Y-%m-%d %H:%i:%S'), ?, '+00:00'), INTERVAL #{day_start} second)", time_zone, time_zone, time_zone]
           else

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -325,7 +325,13 @@ class BasicTest < Minitest::Test
 
   # Daylight Saving Time - issues around transition day
 
+
   def test_daylight_saving_time
+    assert_result_date(:week, "2015-03-08", "2015-03-09 07:15:00", true)
+  end
+
+
+  def test_daylight_saving_time_paris
     paris = ActiveSupport::TimeZone["Paris"]
     create_user(paris.parse("2015-03-30 00:15:00").utc.to_s)
     expected = {Date.parse("2015-03-29") => 1}

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -319,4 +319,20 @@ class BasicTest < Minitest::Test
     }
     assert_equal expected, call_method(:week, :created_at, time_zone: "Brasilia")
   end
+
+
+
+
+  # Daylight Saving Time - issues around transition day
+
+  def test_daylight_saving_time
+    paris = ActiveSupport::TimeZone["Paris"]
+    create_user(paris.parse("2015-03-30 00:15:00").utc.to_s)
+    expected = {Date.parse("2015-03-29") => 1}
+    assert_equal expected, call_method(:week, :created_at, {time_zone: "Paris"})
+  end
+
+
+
+
 end


### PR DESCRIPTION
On a project with a lot of records, at many times in the past, I had "Database and Ruby have inconsistent time zone info"  issues. But only with some records.
I investigated and found that this happens within specific hours around the transition to or from summer time, because around those dates, 1 day is not always 24 hours but may be 25 or 23 hours long.

The SQL syntax had a misplaced CONVERT_TZ, so I moved it.