### PR TITLE
Fix for timezone

### DIFF
--- a/lib/groupdate/magic.rb
+++ b/lib/groupdate/magic.rb
@@ -108,7 +108,7 @@ module Groupdate
                 k.to_time
               end
 
-              k.beginning_of_day.ctime.in_time_zone(time_zone)
+              (k.beginning_of_day + day_start.seconds).ctime.in_time_zone(time_zone)
             end
           end
         end

--- a/lib/groupdate/magic.rb
+++ b/lib/groupdate/magic.rb
@@ -102,11 +102,11 @@ module Groupdate
             end
           else # [:day, :week, :month, :quarter, :year]
             lambda do |k|
-              if k.is_a?(String) || !k.respond_to?(:to_time)
-                utc.parse(k.to_s)
-              else
-                k.to_time
-              end
+              k = if k.is_a?(String) || !k.respond_to?(:to_time)
+                    utc.parse(k.to_s)
+                  else
+                    k.to_time
+                  end
 
               (k.beginning_of_day + day_start.seconds).ctime.in_time_zone(time_zone)
             end

--- a/lib/groupdate/series_builder.rb
+++ b/lib/groupdate/series_builder.rb
@@ -186,7 +186,10 @@ module Groupdate
           last_step = series.last
           loop do
             next_step = last_step + step
-            next_step = round_time(next_step) if next_step.hour.seconds != day_start # add condition to speed up
+
+            if next_step.hour.seconds != day_start # add condition to speed up
+              next_step = round_time(next_step)
+            end
             break unless time_range.cover?(next_step)
 
             if next_step == last_step

--- a/lib/groupdate/series_builder.rb
+++ b/lib/groupdate/series_builder.rb
@@ -186,7 +186,7 @@ module Groupdate
           last_step = series.last
           loop do
             next_step = last_step + step
-            next_step = round_time(next_step) if next_step.hour != day_start # add condition to speed up
+            next_step = round_time(next_step) if next_step.hour.seconds != day_start # add condition to speed up
             break unless time_range.cover?(next_step)
 
             if next_step == last_step

--- a/test/day_start_test.rb
+++ b/test/day_start_test.rb
@@ -219,7 +219,7 @@ class DayStartTest < Minitest::Test
     expected = enumerable? ? "2013-03-09" : "2013-03-10"
 
     time = pt.parse("2013-03-10 03:00:00")
-    assert_result_date :day, expected, time, true, day_start: 2
+    assert_result_date :day, expected, time, true, day_start: 3
   end
 
   def test_dst_week_spring
@@ -227,7 +227,7 @@ class DayStartTest < Minitest::Test
     expected = enumerable? ? "2013-03-03" : "2013-03-10"
 
     time = pt.parse("2013-03-10 03:00:00")
-    assert_result_date :week, expected, time, true, day_start: 2
+    assert_result_date :week, expected, time, true, day_start: 3
   end
 
   def test_dst_hour_of_day_spring

--- a/test/day_start_test.rb
+++ b/test/day_start_test.rb
@@ -219,7 +219,7 @@ class DayStartTest < Minitest::Test
     expected = enumerable? ? "2013-03-09" : "2013-03-10"
 
     time = pt.parse("2013-03-10 03:00:00")
-    assert_result_date :day, expected, time, true, day_start: 3
+    assert_result_date :day, expected, time, true, day_start: 2
   end
 
   def test_dst_week_spring
@@ -227,7 +227,7 @@ class DayStartTest < Minitest::Test
     expected = enumerable? ? "2013-03-03" : "2013-03-10"
 
     time = pt.parse("2013-03-10 03:00:00")
-    assert_result_date :week, expected, time, true, day_start: 3
+    assert_result_date :week, expected, time, true, day_start: 2
   end
 
   def test_dst_hour_of_day_spring


### PR DESCRIPTION
Pull containts fixes for these errors:
1. Error when group by datetime without beginning_of_day for day, week, month, quarter, year periods.
2. Error when datetime convert to timezone from current timezone, offset twice.