### PR TITLE
Test with minimum supported, and latest Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 dist: bionic
 language: ruby
-rvm: 2.6
+rvm:
+  - 2.4
+  - 2.7
 gemfile:
   - Gemfile
   - test/gemfiles/activerecord52.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ gemfile:
   - test/gemfiles/activerecord52.gemfile
   - test/gemfiles/activerecord51.gemfile
   - test/gemfiles/activerecord50.gemfile
+matrix:
+ fast_finish: true
+ exclude:
+   - gemfile: Gemfile
+     rvm: 2.4
 services:
   - postgresql
   - mysql


### PR DESCRIPTION
Hey!

This is a proposal in the form of a PR, what do you think about this? Instead of testing all supported Ruby versions, we could test the `required_ruby_version` and the latest available.

Cheers and thanks for this gem!