### PR TITLE
Added :series_label option for customised query

### DIFF
--- a/lib/groupdate.rb
+++ b/lib/groupdate.rb
@@ -23,6 +23,13 @@ module Groupdate
     end
     result
   end
+
+  def self.process_series_label(relation, result)
+    if relation.groupdate_values
+      result = Groupdate::Magic::Relation.process_series_label(relation, result)
+    end
+    result
+  end
 end
 
 require "groupdate/enumerable"

--- a/lib/groupdate/active_record.rb
+++ b/lib/groupdate/active_record.rb
@@ -4,3 +4,4 @@ require "groupdate/relation"
 
 ActiveRecord::Base.extend(Groupdate::QueryMethods)
 ActiveRecord::Relation.include(Groupdate::Relation)
+ActiveRecord::Relation.prepend(Groupdate::RelationRecords)

--- a/lib/groupdate/relation.rb
+++ b/lib/groupdate/relation.rb
@@ -13,4 +13,11 @@ module Groupdate
       Groupdate.process_result(self, super, default_value: default_value)
     end
   end
+
+  module RelationRecords
+    def records
+      super
+      Groupdate.process_series_label(self, @records)
+    end
+  end
 end

--- a/lib/groupdate/series_builder.rb
+++ b/lib/groupdate/series_builder.rb
@@ -43,6 +43,10 @@ module Groupdate
       result
     end
 
+    def format_series_label(series_label)
+      key_format.call(series_label)
+    end
+
     def round_time(time)
       time = time.to_time.in_time_zone(time_zone)
 

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -243,6 +243,7 @@ class BasicTest < Minitest::Test
     expected = {
       Date.parse("2013-05-03") => 1
     }
+    create_user "2013-05-03"
     assert_equal expected, result(:day, "2013-05-03", false, :created_on)
   end
 
@@ -250,6 +251,7 @@ class BasicTest < Minitest::Test
     expected = {
       Date.parse("2013-05-02") => 1
     }
+    create_user "2013-05-03"
     assert_equal expected, result(:day, "2013-05-03", true, :created_on)
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -74,35 +74,51 @@ class Minitest::Test
       assert_includes error.message, "not supported for SQLite"
       skip
     else
-      User.group_by_period(method, field, options).count
+      if options[:series_label].present?
+        User.select('COUNT(*) AS count').group_by_period(method, field, options).map do |r|
+          [r.send(options[:series_label]), r.count]
+        end.to_h
+      else
+        User.group_by_period(method, field, options).count
+      end
     end
   end
 
   def assert_result_time(method, expected, time_str, time_zone = false, options = {})
+    create_user time_str
     expected = {utc.parse(expected).in_time_zone(time_zone ? "Pacific Time (US & Canada)" : utc) => 1}
     assert_equal expected, result(method, time_str, time_zone, :created_at, options)
+    assert_equal expected, result(method, time_str, time_zone, :created_at, options.merge(series_label: :label))
 
     if ENV["ADAPTER"] == "postgresql"
       # test timestamptz
       assert_equal expected, result(method, time_str, time_zone, :deleted_at, options)
+      assert_equal expected, result(method, time_str, time_zone, :deleted_at, options.merge(series_label: :label))
     end
   end
 
   def assert_result_date(method, expected_str, time_str, time_zone = false, options = {})
     create_user time_str
     expected = {Date.parse(expected_str) => 1}
-    assert_equal expected, call_method(method, :created_at, options.merge(time_zone: time_zone ? "Pacific Time (US & Canada)" : nil))
+    options.merge!(time_zone: time_zone ? "Pacific Time (US & Canada)" : nil)
+    label_options = options.merge(series_label: :label)
+
+    assert_equal expected, call_method(method, :created_at, options)
+    assert_equal expected, call_method(method, :created_at, label_options)
+
     expected = {(time_zone ? pt : utc).parse(expected_str) + options[:day_start].to_f.hours => 1}
-    assert_equal expected, call_method(method, :created_at, options.merge(dates: false, time_zone: time_zone ? "Pacific Time (US & Canada)" : nil))
+    assert_equal expected, call_method(method, :created_at, options.merge(dates: false))
+    assert_equal expected, call_method(method, :created_at, label_options.merge(dates: false))
     # assert_equal expected, call_method(method, :created_on, options.merge(time_zone: time_zone ? "Pacific Time (US & Canada)" : nil))
   end
 
   def assert_result(method, expected, time_str, time_zone = false, options = {})
+    create_user time_str
     assert_equal 1, result(method, time_str, time_zone, :created_at, options)[expected]
+    assert_equal 1, result(method, time_str, time_zone, :created_at, options.merge(series_label: :label))[expected]
   end
 
   def result(method, time_str, time_zone = false, attribute = :created_at, options = {})
-    create_user time_str unless attribute == :deleted_at
     call_method(method, attribute, options.merge(time_zone: time_zone ? "Pacific Time (US & Canada)" : nil))
   end
 


### PR DESCRIPTION
This option is **NOT** supposed to work with AR calculations.

It supports a customized query like:
`users= User.select('COUNT(*) AS total, AVG(age) as average_age').group_by_month(:created_at, series_label: :created_at_month)`

The returned result would have attributes:
- `users.first.created_at_month` 
- `users.first.total` 
- `users.first.average_age` 

The series_label respects other options like `:locale, :dates and :format`