### PR TITLE
Consider nil..nil range as nil

### DIFF
--- a/lib/groupdate/magic.rb
+++ b/lib/groupdate/magic.rb
@@ -69,12 +69,25 @@ module Groupdate
       @day_start ||= ((options[:day_start] || Groupdate.day_start).to_f * 3600).round
     end
 
+    def range
+      @range ||= begin
+        time_range = options[:range]
+
+        if time_range.is_a?(Range) && time_range.begin.nil? && time_range.end.nil?
+          nil
+        else
+          time_range
+        end
+      end
+    end
+
     def series_builder
       @series_builder ||=
         SeriesBuilder.new(
           **options,
           period: period,
           time_zone: time_zone,
+          range: range,
           day_start: day_start,
           week_start: week_start,
           n_seconds: n_seconds

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -409,6 +409,25 @@ class BasicTest < Minitest::Test
     RUBY_VERSION.to_f >= 2.6
   end
 
+  # beginless and endless range
+
+  def test_beginless_and_endless_range
+    skip unless beginless_and_endless_range_supported?
+
+    create_user "2013-05-01"
+    create_user "2013-05-03"
+    expected = {
+      Date.parse("2013-05-01") => 1,
+      Date.parse("2013-05-02") => 0,
+      Date.parse("2013-05-03") => 1
+    }
+    assert_equal expected, call_method(:day, :created_at, series: true, range: nil..nil)
+  end
+
+  def beginless_and_endless_range_supported?
+    RUBY_VERSION.to_f >= 2.6
+  end
+
   # Brasilia Summer Time
 
   def test_brasilia_summer_time


### PR DESCRIPTION
Currently `range: nil..nil` always return zero results as the query includes `WHERE ("users"."created_at" >= NULL)`. This PR changes so that a `nil..nil` range is considered as "without begin and without end".

It makes it easier to compose queries such as 
```rb
User.group_by_year(:created_at, range: starts_at..ends_at).count
```
where `starts_at` and `ends_at` is both optional