### PR TITLE
Use lazy load hook to avoid config issues

### DIFF
--- a/lib/groupdate/active_record.rb
+++ b/lib/groupdate/active_record.rb
@@ -2,5 +2,7 @@ require "active_record"
 require "groupdate/query_methods"
 require "groupdate/relation"
 
-ActiveRecord::Base.extend(Groupdate::QueryMethods)
-ActiveRecord::Relation.include(Groupdate::Relation)
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::Base.extend(Groupdate::QueryMethods)
+  ActiveRecord::Relation.include(Groupdate::Relation)
+end


### PR DESCRIPTION
Running into some issues with config values not loading correctly in a Rails 5.2 app.

Looks like most gems use this `on_load` hook (example: https://github.com/attr-encrypted/attr_encrypted/blob/master/lib/attr_encrypted/adapters/active_record.rb#L139) to ensure "load order". 

Don't know if this is correct at all, but I'm opening to start a convo.