### PR TITLE
rename calculation method to perform_calculation

### DIFF
--- a/lib/groupdate/relation.rb
+++ b/lib/groupdate/relation.rb
@@ -8,7 +8,7 @@ module Groupdate
       attr_accessor :groupdate_values
     end
 
-    def calculate(*args, &block)
+    def perform_calculation(*args, &block)
       default_value = [:count, :sum].include?(args[0]) ? 0 : nil
       Groupdate.process_result(self, super, default_value: default_value)
     end


### PR DESCRIPTION
Hi! 

The current Groupdate::Relation#calculate can be called multiple times if the relation has includes, resulting an "Database and Ruby have inconsistent time zone info." error for me, as the keys are casted twice.

AR Calculations#perform_calculation method was introduced something like 8 years ago. I think the Groupdate should override it instead.