### PR TITLE
Add litedb support

### DIFF
--- a/lib/groupdate/magic.rb
+++ b/lib/groupdate/magic.rb
@@ -204,6 +204,9 @@ module Groupdate
         magic = Groupdate::Magic::Relation.new(**options)
 
         adapter_name = relation.connection.adapter_name
+        if adapter_name == "litedb" then
+          adapter_name = "sqlite"
+        end
         adapter = Groupdate.adapters[adapter_name]
         raise Groupdate::Error, "Connection adapter not supported: #{adapter_name}" unless adapter
 


### PR DESCRIPTION
Hey there! I was just trying to use groupdate in a Rails app using [litestack](https://github.com/oldmoe/litestack). I got this error.

```
>> User.group_by_day(:created_at)
lib/groupdate/magic.rb:208:in `generate_relation': Connection adapter not supported: litedb (Groupdate::Error)
```

All `litedb` really is under the hood is SQLite with some better config defaults for Rails usage. So it's no biggie to just let anybody using that particular connection adapter use groupdate via the `sqlite` support.

Totally understand if you don't wanna have a lil bit of extra noise like this in there. Just seems to be a bit of a SQLite hype 
train coming this year so worth asking at least but no stress!

---

BTW excuse me a sec while I cc a couple folks who I think might be interested to learn that this is a kind of friction that might slow down this fun little SQLite tooling revolution: @oldmoe @fractaledmind