### PR TITLE
Support litestack/litedb

### DIFF
--- a/lib/groupdate.rb
+++ b/lib/groupdate.rb
@@ -45,7 +45,7 @@ end
 
 Groupdate.register_adapter ["Mysql2", "Mysql2Spatial", "Mysql2Rgeo", "Trilogy"], Groupdate::Adapters::MySQLAdapter
 Groupdate.register_adapter ["PostgreSQL", "PostGIS", "Redshift"], Groupdate::Adapters::PostgreSQLAdapter
-Groupdate.register_adapter "SQLite", Groupdate::Adapters::SQLiteAdapter
+Groupdate.register_adapter ["SQLite", "litedb"], Groupdate::Adapters::SQLiteAdapter
 
 require_relative "groupdate/enumerable"
 


### PR DESCRIPTION
Litestack (https://github.com/oldmoe/litestack) provides a production-optimized wrapper around the SQLite3 gem, and names its adapter "litedb" (i.e. `adapter: litedb` in database.yml).

Previously, this project threw an "unsupported adapter: litedb" error, even though litedb is just SQLite3 with some production tweaks.

This adds support for litestack/litedb by registering both names to point to Groupdate::Adapters::SQLiteAdapter.

I looked through the test suite, and didn't see a good place to test this change. If you'd like to add litestack as a test dependency so we can make sure it doesn't throw an error I can add that, but I'll tell you too, I booted this up in a litestack-based app and it works great.