### PR TITLE
Switch from using the instance of klass to the klass method for edge rails.

### DIFF
--- a/lib/groupdate/enumerable.rb
+++ b/lib/groupdate/enumerable.rb
@@ -5,7 +5,7 @@ module Enumerable
         raise ArgumentError, "wrong number of arguments (given #{args.size}, expected 0)" if args.any?
         Groupdate::Magic::Enumerable.group_by(self, period, options, &block)
       elsif respond_to?(:scoping)
-        scoping { @klass.group_by_period(period, *args, **options, &block) }
+        scoping { klass.group_by_period(period, *args, **options, &block) }
       else
         raise ArgumentError, "no block given"
       end
@@ -19,7 +19,7 @@ module Enumerable
       Groupdate::Magic.validate_period(period, options.delete(:permit))
       send("group_by_#{period}", **options, &block)
     else
-      scoping { @klass.group_by_period(period, *args, **options, &block) }
+      scoping { klass.group_by_period(period, *args, **options, &block) }
     end
   end
 end


### PR DESCRIPTION
Our codebase tracks rails edge and we recently started seeing the error `NoMethodError: undefined method `group_by_period' for nil` in our test suite.  I was able to track the error down to rails moving from relying on `klass` to `model` [here](https://github.com/rails/rails/compare/db932716a66a2cb02c132628dd14011dfa1affbb...0f3dbe2f978e07e94503dd9948fa41f994a6681a#diff-18a561656864ea240daf46bdb1f50faace49f9ef74b90bcf667d9bbb17fce084L77). Using `klass`, `model`, `@model` should all work, but I am assuming `klass` would be more backward compatible.
